### PR TITLE
Change alt, shift, key events

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,8 @@ is inserted into the Pluto notebook via
 following JavaScript function:
   ```js
   keysAction(
-    initialKeys,  // Array of keyPressed.key values
-    lastKey,      // keyPressed.key value
-    eventKey,     // event.key
+    keydownEvent,  // event when some key is pressed
+    keys,          // Arrays of elemets of keys combination
     firstLine,    // Custom String
     lastLine      // Custom String
   )
@@ -105,12 +104,12 @@ following JavaScript function:
     Insert "begin ... end" code in Pluto cell
     Keyboard shortcut: Ctrl+Alt+B
   */
-  keysAction(["Control", "Alt"], "b", evt.key, "begin", "end");
+  keysAction(evt, ["Control", "Alt", "b"], "begin", "end");
   ```
 
   Such code must be inserted in the appropriate context ...
   a complete example can be found 
-  [here](https://github.com/lucio-cornejo/custom-pluto/blob/main/custom-Pluto.js#L216).
+  [here](https://github.com/lucio-cornejo/custom-pluto/blob/main/custom-Pluto.js#L297).
 
   You can get the `keyPressed.key` value of the key you want to use
   via executing the following code in your browser console 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ html"""
   Implemented shortcut: `Alt+M`  
 
 - **Toggle cell's input visibilty**: \
-  Implemented shortcut: `Alt+C`  (Non VS Code)
+  Implemented shortcut: `Alt+V`  (Non VS Code)
 
 - **Toggle live documentation**: \
   Implemented shortcut: `Ctrl+Alt+D`  (Non VS Code?)

--- a/custom-Pluto.js
+++ b/custom-Pluto.js
@@ -1,3 +1,14 @@
+// ==UserScript==
+// @name         Custom Pluto
+// @namespace    http://tampermonkey.net/
+// @version      0.2
+// @description  Customize your Pluto notebook
+// @author       Lucio Cornejo
+// @match        *localhost:1234/*
+// @icon         https://www.google.com/s2/favicons?sz=64&domain=tampermonkey.net
+// @grant        none
+// ==/UserScript==
+
 (function() {
   'use strict';
   // Apply customization to notebook


### PR DESCRIPTION
Drop use of a global object to detect multiple keys combinations.
Instead use the special properties of the `"keydown"` **JavaScript** event,
whenever the key `Alt`, `Control` or `Shift`is pressed.